### PR TITLE
Support for autodomain zones custom node name attribute for dns record

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,13 +62,16 @@ end
 
 search(:zones).each do |zone|
   unless zone['autodomain'].nil? || zone['autodomain'] == ''
+    name_attrs = !zone['name_attrs'].nil? && zone['name_attrs'] != '' ? zone['name_attrs'] : ['hostname']
     search(:node, "domain:#{zone['autodomain']}").each do |host|
       next if host['ipaddress'] == '' || host['ipaddress'].nil?
-      zone['zone_info']['records'].push( {
-        "name" => host['hostname'],
-        "type" => "A",
-        "ip" => host['ipaddress']
-      })
+      name_attrs.each do |name_attr|
+        zone['zone_info']['records'].push( {
+          "name" => name_attr == 'name' ? host.name : host[name_attr],
+          "type" => "A",
+          "ip" => host['ipaddress']
+        })
+      end
     end
   end
 


### PR DESCRIPTION
In some cases it is desirable to use node[:name] instead of node[:hostname] as an attribute for DNS record name.
