### PR TITLE
Changes and improvements so the recipe works on Ubuntu 14.04

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'zonefile'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,4 @@ else
 	default[:bind9][:data_path] = "/var/cache/bind"
   default[:bind9][:user] = "bind"
 end
+default[:bind9][:serial_number] = 0

--- a/bin/zonefile_to_databag.rb
+++ b/bin/zonefile_to_databag.rb
@@ -32,8 +32,11 @@ puts "; Record Time To Live: #{zf.soa[:ttl]}"
 # Show A-Records
 puts "; A Records:"
 zf.a.each do |a_record|
-  
-   puts  "{ \"type\": \"A\" , \"name\": \"#{a_record[:name]}\", \"ip\": \"#{a_record[:host]}\"},"
+   ttl_text = ''
+   if !a_record[:ttl].nil? and a_record[:ttl] != '' and a_record[:ttl] != zf.ttl
+     ttl_text = "\"ttl\": \"#{a_record[:ttl]}\", "
+   end
+   puts  "{ \"type\": \"A\", #{ttl_text}\"name\": \"#{a_record[:name]}\", \"ip\": \"#{a_record[:host]}\"},"
 end
 
 puts "; CNAME Records:"

--- a/bin/zonefile_to_databag.rb
+++ b/bin/zonefile_to_databag.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+require 'zonefile'
+require 'optparse'
+
+options = {}
+optparse = OptionParser.new do |opts|
+  opts.banner = "Usage: zonefile_to_databag.rb [options]"
+
+  opts.on("-z", "--zonefile FILE", "Parse Zone File") do |v|
+    options[:zonefile] = v
+  end
+end
+
+begin
+  optparse.parse!
+  if options[:zonefile].nil?
+    puts optparse  
+    raise OptionParser::MissingArgument
+  end 
+end
+
+
+zf = Zonefile.from_file(options[:zonefile])
+puts '; MX-Records'
+zf.mx.each do |mx_record|
+   puts "Mail Exchagne with priority: #{mx_record[:pri]} --> #{mx_record[:host]}"
+end
+
+# Show SOA TTL
+puts "; Record Time To Live: #{zf.soa[:ttl]}"
+
+# Show A-Records
+puts "; A Records:"
+zf.a.each do |a_record|
+  
+   puts  "{ \"type\": \"A\" , \"name\": \"#{a_record[:name]}\", \"ip\": \"#{a_record[:host]}\"},"
+end
+
+puts "; CNAME Records:"
+zf.cname.each do |cname_record|
+   puts "{ \"type\": \"CNAME\" , \"name\": \"#{cname_record[:name]}\", \"ip\": \"#{cname_record[:host]}\"},"
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "bind9"
 maintainer       "Mike Adolphs"
 maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs/Configures bind9"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.1.9"
+version          "0.1.10"
 
 %w{ ubuntu debian centos }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,7 +62,7 @@ end
 
 search(:zones).each do |zone|
   unless zone['autodomain'].nil? || zone['autodomain'] == ''
-    search(:node, "domain:#{zone['autodomain']}").each do |host|
+    search(:node, "fqdn:#{zone['autodomain']}").each do |host|
       next if host['ipaddress'] == '' || host['ipaddress'].nil?
       zone['zone_info']['records'].push( {
         "name" => host['hostname'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,7 +62,8 @@ end
 
 search(:zones).each do |zone|
   unless zone['autodomain'].nil? || zone['autodomain'] == ''
-    search(:node, "fqdn:#{zone['autodomain']}").each do |host|
+    log "fqdn:*.#{zone['autodomain']}"
+    search(:node, "fqdn:*.#{zone['autodomain']}").each do |host|
       next if host['ipaddress'] == '' || host['ipaddress'].nil?
       zone['zone_info']['records'].push( {
         "name" => host['hostname'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -107,6 +107,7 @@ search(:zones).each do |zone|
     variables({
       :domain => zone['domain'],
       :soa => zone['zone_info']['soa'],
+      :soa_apex => zone['zone_info'].has_key?('soa_apex') ? zone['zone_info']['soa_apex'] : '@',
       :contact => zone['zone_info']['contact'],
       :global_ttl => zone['zone_info']['global_ttl'],
       :nameserver => zone['zone_info']['nameserver'],

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,7 @@ package "bind9" do
   action :install
 end
 
-directory "/var/log/bind/" do
+directory "/var/log/named/" do
   owner node[:bind9][:user]
   group node[:bind9][:user]
   mode 0755

--- a/templates/default/named.conf.options.erb
+++ b/templates/default/named.conf.options.erb
@@ -41,7 +41,7 @@ options {
 
 logging {
   channel default_log {
-    file "/var/log/bind/bind.log" versions 5 size 128M;
+    file "/var/log/named/bind.log" versions 5 size 128M;
     print-time yes;
     print-severity yes;
     print-category yes;

--- a/templates/default/named.conf.options.erb
+++ b/templates/default/named.conf.options.erb
@@ -37,6 +37,8 @@ options {
   <% if node[:bind9][:enable_ipv6] %>
     listen-on-v6 { any; };
   <% end %>
+  
+  transfer-format many-answers;
 };
 
 logging {
@@ -49,4 +51,5 @@ logging {
       
   category default { default_log; };
   category general { default_log; };
+  category lame-servers { null; };
 };

--- a/templates/default/zonefile.erb
+++ b/templates/default/zonefile.erb
@@ -1,5 +1,5 @@
 $TTL <%= @global_ttl %>
-@ IN SOA <%= @soa %> <%= @contact %> (
+<%= @soa_apex %> IN SOA <%= @soa %> <%= @contact %> (
                 <%%= @serial %> ; serial [yyyyMMddNN]
                 4H      ; refresh
                 30M     ; retry


### PR DESCRIPTION
Implementing this, there were a few issues addressed in this pull request:
-  Berkshelf cannot depend on this cookbook if it doesn't have a name
-  Added a utility to convert a zonefile to json format; it's a work in progress but saved me some time; if useful to anyone I can finish it
-  Ubuntu apparmor insists that logfiles are in /var/log/named not /var/log/bind (might want to make this more universal so it is tested and works across distros).
-  Serial number generation is > 32 bits so rejected per RFC and at least this version of bind9.  Because my client also likes YYYYMMDD based format I put a tad more work into serial #. It's not perfect since (1) limited to 100 zonefile changes /day; and (2) the day that you hit 99, your next serial will be before your current one sequentially.  Someone, somewhere might find that surprising.

Do you need issues created for any of these?  And please send comments as I would be happy to revise/improve what I've got so far.
